### PR TITLE
Recursive load from folder and new template

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -65,7 +65,8 @@ classes = [
     # BSEQ_OT_import_zip,
     # BSEQ_OT_delete_zips,
     # BSEQ_addon_preferences,
-    BSEQ_OT_load_all
+    BSEQ_OT_load_all,
+    BSEQ_OT_load_all_recursive
 ]
 
 def register():

--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "Sequence Loader",
     "description": "Loader for meshio supported mesh files/ simulation sequences",
     "author": "Interactive Computer Graphics",
-    "version": (0, 3, 1),
+    "version": (0, 3, 2),
     "blender": (4, 0, 0),
     "warning": "",
     "support": "COMMUNITY",

--- a/bseq/__init__.py
+++ b/bseq/__init__.py
@@ -1,5 +1,5 @@
 from bseq.utils import refresh_obj
-from .operators import BSEQ_OT_load, BSEQ_OT_edit, BSEQ_OT_resetpt, BSEQ_OT_resetmesh, BSEQ_OT_resetins, BSEQ_OT_set_as_split_norm, BSEQ_OT_remove_split_norm, BSEQ_OT_disable_selected, BSEQ_OT_enable_selected, BSEQ_OT_refresh_seq, BSEQ_OT_disable_all, BSEQ_OT_enable_all, BSEQ_OT_refresh_sequences, BSEQ_OT_set_start_end_frames, BSEQ_OT_batch_sequences, BSEQ_PT_batch_sequences_settings, BSEQ_OT_meshio_object, BSEQ_OT_import_zip, BSEQ_OT_delete_zips, BSEQ_addon_preferences, BSEQ_OT_load_all
+from .operators import BSEQ_OT_load, BSEQ_OT_edit, BSEQ_OT_resetpt, BSEQ_OT_resetmesh, BSEQ_OT_resetins, BSEQ_OT_set_as_split_norm, BSEQ_OT_remove_split_norm, BSEQ_OT_disable_selected, BSEQ_OT_enable_selected, BSEQ_OT_refresh_seq, BSEQ_OT_disable_all, BSEQ_OT_enable_all, BSEQ_OT_refresh_sequences, BSEQ_OT_set_start_end_frames, BSEQ_OT_batch_sequences, BSEQ_PT_batch_sequences_settings, BSEQ_OT_meshio_object, BSEQ_OT_import_zip, BSEQ_OT_delete_zips, BSEQ_addon_preferences, BSEQ_OT_load_all, BSEQ_OT_load_all_recursive
 from .properties import BSEQ_scene_property, BSEQ_obj_property, BSEQ_mesh_property
 from .panels import BSEQ_UL_Obj_List, BSEQ_List_Panel, BSEQ_Settings, BSEQ_PT_Import, BSEQ_PT_Import_Child1, BSEQ_PT_Import_Child2, BSEQ_Globals_Panel, BSEQ_Advanced_Panel, BSEQ_Templates, BSEQ_UL_Att_List, draw_template
 from .messenger import subscribe_to_selected, unsubscribe_to_selected
@@ -62,5 +62,6 @@ __all__ = [
     "BSEQ_OT_import_zip",
     "BSEQ_OT_delete_zips",
     "BSEQ_addon_preferences",
-    "BSEQ_OT_load_all"
+    "BSEQ_OT_load_all",
+    "BSEQ_OT_load_all_recursive"
 ]

--- a/bseq/panels.py
+++ b/bseq/panels.py
@@ -292,11 +292,13 @@ class BSEQ_PT_Import_Child1(BSEQ_Panel, bpy.types.Panel):
             col3.prop(importer_prop, "fileseq", text="")
             col4.operator("bseq.refreshall", text='', icon="FILE_REFRESH")
 
-        split = layout.split(factor=0.7)
+        split = layout.split(factor=0.5)
         col1 = split.column()
         col2 = split.column()
         col1.operator("sequence.load")
-        col2.operator("bseq.load_all")
+        row = col2.row()
+        row.operator("bseq.load_all")
+        row.operator("bseq.load_all_recursive")
 
         # split = layout.split(factor=0.5)
         # col1 = split.column()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,9 +7,9 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'blender-sequence-loader'
-copyright = '2022, InteractiveComputerGraphics'
+copyright = '2024, InteractiveComputerGraphics'
 author = 'InteractiveComputerGraphics'
-release = '0.3.1'
+release = '0.3.2'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/template/Comparison Render.py
+++ b/template/Comparison Render.py
@@ -1,0 +1,66 @@
+import bpy
+
+# Utilities for comparison rendering
+def toggle_on_single(obj):
+    obj.hide_render = False
+    if isinstance(obj, bpy.types.Object) and obj.BSEQ.init:
+        obj.BSEQ.enabled = True
+
+def toggle_on(objs):
+    if type(objs) == list:
+        for obj in objs:
+            if isinstance(obj, bpy.types.Collection):
+                toggle_on_single(obj)
+                for child in obj.all_objects:
+                    toggle_on_single(child)
+            else:
+                toggle_on_single(obj)
+    else:
+        if isinstance(objs, bpy.types.Collection):
+            toggle_on_single(objs)
+            for child in objs.all_objects:
+                toggle_on_single(child)
+        else:
+            toggle_on_single(objs)
+
+def toggle_off_single(obj):
+    obj.hide_render = True
+    if isinstance(obj, bpy.types.Object) and obj.BSEQ.init:
+        obj.BSEQ.enabled = False
+
+def toggle_off(objs):
+    if type(objs) == list:
+        for obj in objs:
+            toggle_off_single(obj)
+            if isinstance(obj, bpy.types.Collection):
+                for child in obj.all_objects:
+                    toggle_off_single(child)
+    else:
+        toggle_off_single(objs)
+        if isinstance(objs, bpy.types.Collection):
+            for child in objs.all_objects:
+                toggle_off_single(child)
+            
+def toggle_off_all():
+    for obj in bpy.data.objects:
+        toggle_off_single(obj)    
+            
+def toggle_on_all():
+    for obj in bpy.data.objects:
+        toggle_on_single(obj)           
+
+# Declare which collection to render comparison for
+# Change this to the name of the collection you want to render
+comparison_collection = "Sequences"
+
+# Iterate over children in the collection
+comparison_objects = list(bpy.data.collections[comparison_collection].children)
+orig_path = bpy.context.scene.render.filepath
+for obj in comparison_objects:
+    toggle_off(comparison_objects)
+    toggle_on(obj)
+    bpy.context.scene.render.filepath = f"{orig_path}/{obj.name}/"
+#    bpy.ops.render.render(write_still=True)
+    bpy.ops.render.render(animation=True)
+    
+bpy.context.scene.render.filepath = orig_path

--- a/template/Comparison Render.py
+++ b/template/Comparison Render.py
@@ -5,41 +5,39 @@ def toggle_on_single(obj):
     obj.hide_render = False
     if isinstance(obj, bpy.types.Object) and obj.BSEQ.init:
         obj.BSEQ.enabled = True
+        for child in obj.children:
+            toggle_on_single(child)
+    elif isinstance(obj, bpy.types.Collection):
+        for child in obj.objects:
+            toggle_on_single(child)
+        for child in obj.children:
+            toggle_on_single(child)
 
 def toggle_on(objs):
     if type(objs) == list:
         for obj in objs:
-            if isinstance(obj, bpy.types.Collection):
-                toggle_on_single(obj)
-                for child in obj.all_objects:
-                    toggle_on_single(child)
-            else:
-                toggle_on_single(obj)
+            toggle_on_single(obj)
     else:
-        if isinstance(objs, bpy.types.Collection):
-            toggle_on_single(objs)
-            for child in objs.all_objects:
-                toggle_on_single(child)
-        else:
-            toggle_on_single(objs)
+        toggle_on_single(objs)
 
 def toggle_off_single(obj):
     obj.hide_render = True
     if isinstance(obj, bpy.types.Object) and obj.BSEQ.init:
         obj.BSEQ.enabled = False
+        for child in obj.children:
+            toggle_off_single(child)
+    elif isinstance(obj, bpy.types.Collection):
+        for child in obj.objects:
+            toggle_off_single(child)
+        for child in obj.children:
+            toggle_off_single(child)
 
 def toggle_off(objs):
     if type(objs) == list:
         for obj in objs:
             toggle_off_single(obj)
-            if isinstance(obj, bpy.types.Collection):
-                for child in obj.all_objects:
-                    toggle_off_single(child)
     else:
         toggle_off_single(objs)
-        if isinstance(objs, bpy.types.Collection):
-            for child in objs.all_objects:
-                toggle_off_single(child)
             
 def toggle_off_all():
     for obj in bpy.data.objects:
@@ -47,14 +45,14 @@ def toggle_off_all():
             
 def toggle_on_all():
     for obj in bpy.data.objects:
-        toggle_on_single(obj)           
+        toggle_on_single(obj)  
 
 # Declare which collection to render comparison for
 # Change this to the name of the collection you want to render
 comparison_collection = "Sequences"
 
 # Iterate over children in the collection
-comparison_objects = list(bpy.data.collections[comparison_collection].children)
+comparison_objects = list(bpy.data.collections[comparison_collection].children) + list(bpy.data.collections[comparison_collection].objects)
 orig_path = bpy.context.scene.render.filepath
 for obj in comparison_objects:
     toggle_off(comparison_objects)


### PR DESCRIPTION
This PR adds the `load_all_recursive` operator. When a base directory is selected, this operator will recurse through all subdirectories and load all sequences that are detected. For easier organization, the folder structure is mapped to a structure of collections.

A new python template is also added, which adds some utility for doing quick comparison renders, by enabling and disabling objects and collections within another collection.