### PR TITLE
Add missing version check for use_auto_smooth

### DIFF
--- a/bseq/importer.py
+++ b/bseq/importer.py
@@ -204,7 +204,7 @@ def update_mesh(meshio_mesh, mesh):
 
         # set as split normal per vertex
         if mesh.BSEQ.split_norm_att_name and mesh.BSEQ.split_norm_att_name == k:
-            # If blender version is less than 4.1.0, then dont set auto smooth.
+            # If blender version is greater than 4.1.0, then don't set auto smooth.
             # It has been removed and normals will be used automatically if they are set.
             # https://developer.blender.org/docs/release_notes/4.1/python_api/#mesh
             if bpy.app.version < (4, 1, 0):
@@ -217,8 +217,9 @@ def update_mesh(meshio_mesh, mesh):
         
         # set split normal per loop per vertex
         if mesh.BSEQ.split_norm_att_name and mesh.BSEQ.split_norm_att_name == k:
-            # Currently hard-coded for .obj files
-            mesh.use_auto_smooth = True
+            if bpy.app.version < (4, 1, 0):
+                mesh.use_auto_smooth = True
+            # currently hard-coded for .obj files
             indices = [item for sublist in meshio_mesh.cell_data["obj:vn_face_idx"][0] for item in sublist]
             mesh.normals_split_custom_set([meshio_mesh.field_data["obj:vn"][i - 1] for i in indices])
 


### PR DESCRIPTION
Commit 0783423b1860895235bb8b7a21275d53f2866c59 missed a version check for the `use_auto_smooth`. This can crash Blender Versions >= 4.1:
```
AttributeError: 'Mesh' object has no attribute 'use_auto_smooth'
Error in bpy.app.handlers.frame_change_post[0]:
Traceback (most recent call last):
  File "/home/floeschner/.config/blender/4.3/extensions/user_default/sequence_loader/bseq/importer.py", line 355, in update_obj
    update_mesh(meshio_mesh, obj.data)
  File "/home/floeschner/.config/blender/4.3/extensions/user_default/sequence_loader/bseq/importer.py", line 221, in update_mesh
    mesh.use_auto_smooth = True
    ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Mesh' object has no attribute 'use_auto_smooth'
```