### PR TITLE
Fix problems with relative paths on Windows

### DIFF
--- a/bseq/callback.py
+++ b/bseq/callback.py
@@ -1,30 +1,36 @@
 import bpy
 import fileseq
+import traceback
+
+from .utils import show_message_box
 
 #  Code here are mostly about the callback/update/items functions used in properties.py
 
 file_sequences = []
 
 def update_path(self, context):
+    '''
+    Detects all the file sequences in the directory
+    '''
+
     # When the path has been changed, reset the selected sequence to None
     context.scene.BSEQ['fileseq'] = 1
     context.scene.BSEQ.use_pattern = False
     context.scene.BSEQ.pattern = ""
-
-    '''
-    Detects all the file sequences in the directory
-    '''
+    file_sequences.clear()
     
     p = context.scene.BSEQ.path
     try:
-        f = fileseq.findSequencesOnDisk(p)
-    except:
-        return [("None", "No sequence detected", "", 1)]
+        f = fileseq.findSequencesOnDisk(bpy.path.abspath(p))
+    except Exception as e:
+        show_message_box("Error when reading path\n" + traceback.format_exc(),
+                         "fileseq Error" + str(e),
+                         icon="ERROR")
+        return None
 
     if not f:
-        return [("None", "No sequence detected", "", 1)]
+        return None
 
-    file_sequences.clear()
     if len(f) >= 30:
         file_sequences.append(("None", "Too much sequence detected, could be false detection, please use pattern below", "", 1))
     else:

--- a/bseq/importer.py
+++ b/bseq/importer.py
@@ -262,13 +262,14 @@ def create_obj(fileseq, use_relative, root_path, transform_matrix=Matrix.Identit
     object = bpy.data.objects.new(name, mesh)
 
     #  create the object
+    full_path = str(fileseq)
+    path = os.path.dirname(full_path)
+    pattern = os.path.basename(full_path)
     if use_relative:
-        full_path = get_relative_path(str(fileseq), root_path)
-    else:
-        full_path = str(fileseq)
+        path = get_relative_path(path, root_path)
     # path is only the directory in which the file is located
-    object.BSEQ.path = os.path.dirname(full_path)
-    object.BSEQ.pattern = os.path.basename(full_path)
+    object.BSEQ.path = path
+    object.BSEQ.pattern = pattern
     object.BSEQ.current_file = filepath
     object.BSEQ.init = True
     object.BSEQ.enabled = enabled

--- a/bseq/utils.py
+++ b/bseq/utils.py
@@ -51,7 +51,7 @@ def refresh_obj(obj, scene):
     is_relative = obj.BSEQ.path.startswith("//")
     fs = get_absolute_path(obj, scene)
     fs = fileseq.findSequenceOnDisk(fs)
-    fs = fileseq.findSequenceOnDisk(fs.dirname() + fs.basename() + "@" + fs.extension())
+    #fs = fileseq.findSequenceOnDisk(fs.dirname() + fs.basename() + "@" + fs.extension())
 
     full_path = str(fs)
     path = os.path.dirname(full_path)

--- a/bseq/utils.py
+++ b/bseq/utils.py
@@ -21,7 +21,6 @@ def show_message_box(message="", title="Message Box", icon="INFO"):
     stop_animation()
     bpy.context.window_manager.popup_menu(draw, title=title, icon=icon)
 
-
 def stop_animation():
     if bpy.context.screen.is_animation_playing:
         #  if playing animation, then stop it, otherwise it will keep showing message box
@@ -29,17 +28,18 @@ def stop_animation():
 
 def get_relative_path(path, root_path):
     if root_path != "":
-        path = bpy.path.relpath(path, start=root_path)
+        rel_path = bpy.path.relpath(path, start=bpy.path.abspath(root_path))
     else:
-        path = bpy.path.relpath(path)    
-    return path
+        rel_path = bpy.path.relpath(path)    
+    return rel_path
 
 # convert relative path to absolute path
 def convert_to_absolute_path(path, root_path):
+    # Additional call to os.path.abspath removes any "/../"" in the path (can be a problem on Windows)
     if root_path != "":
-        path = bpy.path.abspath(path, start=root_path)
+        path = os.path.abspath(bpy.path.abspath(path, start=bpy.path.abspath(root_path)))
     else:
-        path = bpy.path.abspath(path)    
+        path = os.path.abspath(bpy.path.abspath(path))
     return path
 
 def get_absolute_path(obj, scene):
@@ -47,19 +47,21 @@ def get_absolute_path(obj, scene):
     full_path = convert_to_absolute_path(full_path, scene.BSEQ.root_path)
     return full_path
 
-
 def refresh_obj(obj, scene):
     is_relative = obj.BSEQ.path.startswith("//")
-    print("is_relative: ", is_relative)
     fs = get_absolute_path(obj, scene)
     fs = fileseq.findSequenceOnDisk(fs)
     fs = fileseq.findSequenceOnDisk(fs.dirname() + fs.basename() + "@" + fs.extension())
-    obj.BSEQ.start_end_frame = (fs.start(), fs.end())
-    fs = str(fs)
+
+    full_path = str(fs)
+    path = os.path.dirname(full_path)
+    pattern = os.path.basename(full_path)
     if is_relative:
-        fs = get_relative_path(fs, scene.BSEQ.root_path)
-    obj.BSEQ.path = os.path.dirname(fs)
-    obj.BSEQ.pattern = os.path.basename(fs)
+        path = get_relative_path(path, scene.BSEQ.root_path)
+
+    obj.BSEQ.path = path
+    obj.BSEQ.pattern = pattern
+    obj.BSEQ.start_end_frame = (fs.start(), fs.end())
 
 def load_meshio_from_path(fileseq, filepath, obj = None):
     try:


### PR DESCRIPTION
On Windows, sequence loading with relative paths were broken (not sure when it worked for the last time). More specifically:

- `fileseq.findSequencesOnDisk` cannot deal with Blender relative paths (starting with `//`) and needs a kind-of absolute path. Solution: use `bpy.path.abspath`
- The same applies to `fileseq.findSequenceOnDisk`, however this also seems to break with paths containing `..`. Solution: convert to a fully absolute path with `os.path.abspath`
- Extracting a sequence directory and pattern with `os.path.dirname`/`basename` does not work on Blender relative paths. Solution: do this before converting absolute to relative paths
- At least on Windows, `bpy.path.relpath` and `bpy.path.abspath` do not work correctly with a Blender relative path as `start` argument. Solution: turn it into an absolute path with `bpy.path.abspath`

I tested these changes on MacOS and they seem to work as intended.

Also this PR changes the recursive load to include the selected folder itself which is more in line with the common understanding of recursive commands. Alternatively, we could change the name to something like "load from subfolders recursively" or something like this.