### PR TITLE
logic error when the mesh does not contain any cells

### DIFF
--- a/bseq/importer.py
+++ b/bseq/importer.py
@@ -162,7 +162,7 @@ def update_mesh(meshio_mesh, mesh):
     else:
         mesh.clear_geometry()
         mesh.vertices.add(n_verts)
-        mesh.edges.add(len(edge_data))
+        mesh.edges.add(len(edges))
         mesh.loops.add(n_loop)
         mesh.polygons.add(n_poly)
 


### PR DESCRIPTION
Should address the problem raised in #38. Essentially, there was an error in the logic when the loaded files contained to geometry whatsoever, as is the case when point clouds are saved in .obj format. This error did not occur with, e.g., .vtk files as they still denote the point cloud as "point" cells.