### PR TITLE
Add property option flags

### DIFF
--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -3,7 +3,7 @@ schema_version = "1.0.0"
 # Example of manifest file for a Blender extension
 # Change the values according to your extension
 id = "sequence_loader"
-version = "0.3.5"
+version = "0.3.6"
 name = "Blender Sequence Loader"
 tagline = "Just-in-time loader for meshio-supported mesh file sequences"
 maintainer = "Stefan Rhys Jeske <contact@srjeske.de>"

--- a/bseq/properties.py
+++ b/bseq/properties.py
@@ -7,6 +7,7 @@ class BSEQ_scene_property(bpy.types.PropertyGroup):
                                    subtype="DIR_PATH",
                                    description="You need to go to the folder with the sequence, then click \"Accept\"",
                                    update=update_path,
+                                   options={'PATH_SUPPORTS_BLEND_RELATIVE' if bpy.app.version >= (4, 5, 0) else ''}
                                    )
     
     use_relative: bpy.props.BoolProperty(name='Relative Paths', 
@@ -24,6 +25,7 @@ class BSEQ_scene_property(bpy.types.PropertyGroup):
                                         description="Select root folder for all relative paths. If empty, root is folder of the Blender file",
                                         update=update_path,
                                         default="",
+                                        options={'PATH_SUPPORTS_BLEND_RELATIVE' if bpy.app.version >= (4, 5, 0) else ''}
                                         )
     
     fileseq: bpy.props.EnumProperty(
@@ -120,7 +122,7 @@ class BSEQ_obj_property(bpy.types.PropertyGroup):
                                     description="If deactivated, sequence won't be updated each frame")
     use_advance: bpy.props.BoolProperty(default=False)
     script_name: bpy.props.StringProperty(name="Script name")
-    path: bpy.props.StringProperty(name="Path of sequence", subtype="DIR_PATH")
+    path: bpy.props.StringProperty(name="Path of sequence", subtype="DIR_PATH", options={'PATH_SUPPORTS_BLEND_RELATIVE' if bpy.app.version >= (4, 5, 0) else ''})
     pattern: bpy.props.StringProperty(name="Pattern of sequence")
     current_file: bpy.props.StringProperty(description="File of sequence that is currently loaded")
     frame: bpy.props.IntProperty(name="Frame")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = 'blender-sequence-loader'
 copyright = '2025, InteractiveComputerGraphics'
 author = 'InteractiveComputerGraphics'
-release = '0.3.5'
+release = '0.3.6'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
While relative path handling did not break, Blender added an option with 4.5 that marks relative paths as invalid when the `'PATH_SUPPORTS_BLEND_RELATIVE'` is not set. This has been added as conditional to the current blender version.